### PR TITLE
Only set LC_NUMERIC instead of LC_ALL

### DIFF
--- a/src/svg.c
+++ b/src/svg.c
@@ -706,7 +706,8 @@ title_to_svg(char* buffer,
 char *
 chart_to_svg(chart* chart)
 {
-    setlocale(LC_ALL, "C");
+    char * current = setlocale(LC_NUMERIC, NULL);
+    setlocale(LC_NUMERIC, "C");
     char * buffer = malloc(1024*1024*sizeof(char));
     memset(buffer, 0, 1024*1024);
     svg_header(buffer, chart->width, chart->height);
@@ -737,6 +738,6 @@ chart_to_svg(chart* chart)
     ticks_free(x_t);
     ticks_free(y_t);
 
-    // setlocale(LC_ALL, "C");
+    setlocale(LC_NUMERIC, current);
     return buffer;
 }


### PR DESCRIPTION
It's enough to set the decimal-point character to the default locale. Also reset locale after rendering. Leaving locale as C breaks PDF export in Marker:
https://github.com/fabiocolacio/Marker/issues/304#issuecomment-696388392